### PR TITLE
Improve keyboard key name handling

### DIFF
--- a/source/Observatory/Keyboard/Keyboard.Modifier.swift
+++ b/source/Observatory/Keyboard/Keyboard.Modifier.swift
@@ -42,12 +42,15 @@ public struct KeyboardModifier: RawRepresentable, OptionSet {
     public static let shiftKey: KeyboardModifier = .init(Carbon.shiftKey)
 
     public var name: String? {
+        // Keep the order: https://developer.apple.com/design/human-interface-guidelines/inputs/keyboards/#custom-keyboard-shortcuts
+        //  > List modifier keys in the correct order. If you use more than one modifier key in a custom
+        //  > shortcut, always list them in this order: Control, Option, Shift, Command.
         var string: String = ""
-        if self.contains(.controlKey) { string += "⌃" }
-        if self.contains(.optionKey) { string += "⌥" }
-        if self.contains(.capsLockKey) { string += "⇪" }
-        if self.contains(.shiftKey) { string += "⇧" }
-        if self.contains(.commandKey) { string += "⌘" }
+        if self.contains(.controlKey) { string += KeyboardKey.control.name ?? "" }
+        if self.contains(.optionKey) { string += KeyboardKey.option.name ?? "" }
+        if self.contains(.capsLockKey) { string += KeyboardKey.capsLock.name ?? "" }
+        if self.contains(.shiftKey) { string += KeyboardKey.shift.name ?? "" }
+        if self.contains(.commandKey) { string += KeyboardKey.command.name ?? "" }
         return string == "" ? nil : string
     }
 }

--- a/source/Observatory/Test/Keyboard/Test.Keyboard.Key.swift
+++ b/source/Observatory/Test/Keyboard/Test.Keyboard.Key.swift
@@ -1,3 +1,4 @@
+import Carbon
 import Foundation
 import Nimble
 import Observatory
@@ -7,7 +8,19 @@ internal class KeyboardKeySpec: Spec {
     override internal func spec() {
         it("can return human-readable key name") {
             expect(KeyboardKey.a.name).to(equal("A"))
+            expect(KeyboardKey.a.name(layout: .ascii)).to(equal("A"))
             expect(KeyboardKey.escape.name).to(equal("⎋"))
+            expect(KeyboardKey.escape.name(map: [.escape: "Esc"])).to(equal("Esc"))
+        }
+
+        it("can return key name in specified keyboard layout") {
+            // Using properties filter to get the language doesn't work as expected and returns a different input… 🤔
+            let inputSources = TISCreateInputSourceList(nil, true).takeRetainedValue() as? [TISInputSource]
+            let inputSource = inputSources?.first(where: { unsafeBitCast(TISGetInputSourceProperty($0, kTISPropertyInputSourceID), to: CFString.self) as String == "com.apple.keylayout.Ukrainian" })
+            let layoutData = inputSource.map({ unsafeBitCast(TISGetInputSourceProperty($0, kTISPropertyUnicodeKeyLayoutData), to: CFData.self) as NSData })
+            let layout = layoutData.map({ $0.bytes.bindMemory(to: UCKeyboardLayout.self, capacity: $0.length) })
+            expect(layout).toNot(beNil())
+            KeyboardKey.a.name(layout: layout) == "Ф"
         }
     }
 }


### PR DESCRIPTION
- Don't translate key names by default and stick with English names.
- Add support for specifying layout, either via `KeyboardKey.Layout` enum shorthand or explicit `UCKeyboardLayout`.