### PR TITLE
Optimize GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,14 +4,26 @@
 name: Lint & Test
 
 on:
-  push:
+  push: { branches: [ main ] }
   pull_request:
-    types: [ opened, reopened ]
   workflow_dispatch:
 
 jobs:
+  skip:
+    name: Pre-Check & Skip
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.check.outputs.should_skip }}
+    steps:
+      - name: Skip duplicate actions
+        id: check
+        uses: fkirc/skip-duplicate-actions@v5
+
   main:
     name: Lint & Test
+    needs: skip
+    if: needs.skip.outputs.should_skip != 'true'
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
Avoid duplicate runs in PRs (by configuration) and add a skip check job to avoid the same code checks, e.g., after merges or rebases, see [actions/skip-duplicate-actions](https://github.com/marketplace/actions/skip-duplicate-actions) for details.